### PR TITLE
Basic gem setup, Client, and Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,35 +1,10 @@
-*.gem
-*.rbc
-/.config
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
 /coverage/
-/InstalledFiles
+/doc/
 /pkg/
 /spec/reports/
-/test/tmp/
-/test/version_tmp/
 /tmp/
-
-## Specific to RubyMotion:
-.dat*
-.repl_history
-build/
-
-## Documentation cache and generated files:
-/.yardoc/
-/_yardoc/
-/doc/
-/rdoc/
-
-## Environment normalisation:
-/.bundle/
-/vendor/bundle
-/lib/bundler/man/
-
-# for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
-
-# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
-.rvmrc
+.env

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,258 @@
+AllCops:
+  Exclude:
+    - bin/**/*
+    - Gemfile.lock
+
+AccessorMethodName:
+  Enabled: false
+
+ActionFilter:
+  Enabled: false
+
+Alias:
+  Enabled: false
+
+ArrayJoin:
+  Enabled: false
+
+AsciiComments:
+  Enabled: false
+
+AsciiIdentifiers:
+  Enabled: false
+
+Attr:
+  Enabled: false
+
+BlockNesting:
+  Enabled: false
+
+CaseEquality:
+  Enabled: false
+
+CharacterLiteral:
+  Enabled: false
+
+ClassAndModuleChildren:
+  Enabled: false
+
+ClassLength:
+  Enabled: false
+
+ClassVars:
+  Enabled: false
+
+CollectionMethods:
+  PreferredMethods:
+    find: detect
+    reduce: inject
+    collect: map
+    find_all: select
+
+ColonMethodCall:
+  Enabled: false
+
+CommentAnnotation:
+  Enabled: false
+
+CyclomaticComplexity:
+  Enabled: false
+
+Delegate:
+  Enabled: false
+
+DeprecatedHashMethods:
+  Enabled: false
+
+Documentation:
+  Enabled: false
+
+DotPosition:
+  EnforcedStyle: trailing
+
+DoubleNegation:
+  Enabled: false
+
+EachWithObject:
+  Enabled: false
+
+EmptyLiteral:
+  Enabled: false
+
+Encoding:
+  Enabled: false
+
+EvenOdd:
+  Enabled: false
+
+FileName:
+  Enabled: false
+
+FlipFlop:
+  Enabled: false
+
+FormatString:
+  Enabled: false
+
+GlobalVars:
+  Enabled: false
+
+GuardClause:
+  Enabled: false
+
+IfUnlessModifier:
+  Enabled: false
+
+IfWithSemicolon:
+  Enabled: false
+
+Lambda:
+  Enabled: false
+
+LambdaCall:
+  Enabled: false
+
+LineEndConcatenation:
+  Enabled: false
+
+LineLength:
+  Max: 80
+
+MethodLength:
+  Enabled: false
+
+ModuleFunction:
+  Enabled: false
+
+NegatedIf:
+  Enabled: false
+
+NegatedWhile:
+  Enabled: false
+
+Next:
+  Enabled: false
+
+NilComparison:
+  Enabled: false
+
+Not:
+  Enabled: false
+
+NumericLiterals:
+  Enabled: false
+
+OneLineConditional:
+  Enabled: false
+
+OpMethod:
+  Enabled: false
+
+ParameterLists:
+  Enabled: false
+
+PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%': '{}'
+
+PerlBackrefs:
+  Enabled: false
+
+PredicateName:
+  NamePrefixBlacklist:
+    - is_
+
+Proc:
+  Enabled: false
+
+RaiseArgs:
+  Enabled: false
+
+RegexpLiteral:
+  Enabled: false
+
+SelfAssignment:
+  Enabled: false
+
+SingleLineBlockParams:
+  Enabled: false
+
+SingleLineMethods:
+  Enabled: false
+
+SignalException:
+  Enabled: false
+
+SpecialGlobalVars:
+  Enabled: false
+
+StringLiterals:
+  EnforcedStyle: single_quotes
+
+VariableInterpolation:
+  Enabled: false
+
+TrailingComma:
+  Enabled: false
+
+TrivialAccessors:
+  Enabled: false
+
+VariableInterpolation:
+  Enabled: false
+
+WhenThen:
+  Enabled: false
+
+WhileUntilModifier:
+  Enabled: false
+
+WordArray:
+  Enabled: false
+
+# Lint
+
+AmbiguousOperator:
+  Enabled: false
+
+AmbiguousRegexpLiteral:
+  Enabled: false
+
+AssignmentInCondition:
+  Enabled: false
+
+ConditionPosition:
+  Enabled: false
+
+DeprecatedClassMethods:
+  Enabled: false
+
+ElseLayout:
+  Enabled: false
+
+HandleExceptions:
+  Enabled: false
+
+InvalidCharacterLiteral:
+  Enabled: false
+
+LiteralInCondition:
+  Enabled: false
+
+LiteralInInterpolation:
+  Enabled: false
+
+Loop:
+  Enabled: false
+
+ParenthesesAsGroupedExpression:
+  Enabled: false
+
+RequireParentheses:
+  Enabled: false
+
+UnderscorePrefixedVariableName:
+  Enabled: false
+
+Void:
+  Enabled: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+group :development do
+  gem 'pry'
+end
+
+group :test do
+  gem 'rspec'
+  gem 'webmock'
+end
+
+# Specify your gem's dependencies in stattleship-ruby.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'bundler/gem_tasks'

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'stattleship'
+
+require 'pry'
+Pry.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/stattleship.rb
+++ b/lib/stattleship.rb
@@ -1,0 +1,7 @@
+require 'stattleship/ruby/version'
+
+module Stattleship
+  module Ruby
+    # Your code goes here...
+  end
+end

--- a/lib/stattleship.rb
+++ b/lib/stattleship.rb
@@ -1,4 +1,5 @@
 require 'net/https'
 
 require 'stattleship/version'
+require 'stattleship/configuration'
 require 'stattleship/client'

--- a/lib/stattleship.rb
+++ b/lib/stattleship.rb
@@ -1,7 +1,4 @@
-require 'stattleship/ruby/version'
+require 'net/https'
 
-module Stattleship
-  module Ruby
-    # Your code goes here...
-  end
-end
+require 'stattleship/version'
+require 'stattleship/client'

--- a/lib/stattleship/client.rb
+++ b/lib/stattleship/client.rb
@@ -1,8 +1,7 @@
 module Stattleship
   class Client
-    BASE_API_URI = URI('https://stattleship.com').freeze
-
-    def initialize(path:, token:)
+    def initialize(path:, token: Stattleship.configuration.api_token)
+      @base_uri = Stattleship.configuration.base_uri.freeze
       @path = path
       @token = token
     end
@@ -28,10 +27,10 @@ module Stattleship
 
     private
 
-    attr_reader :path, :token
+    attr_reader :base_uri, :path, :token
 
     def http
-      @http ||= Net::HTTP.new(BASE_API_URI.host, BASE_API_URI.port)
+      @http ||= Net::HTTP.new(base_uri.host, base_uri.port)
     end
 
     def configure_http
@@ -40,7 +39,7 @@ module Stattleship
     end
 
     def endpoint
-      @endpoint ||= Net::HTTP::Get.new("#{BASE_API_URI}/#{path}", headers)
+      @endpoint ||= Net::HTTP::Get.new("#{base_uri}/#{path}", headers)
     end
   end
 end

--- a/lib/stattleship/client.rb
+++ b/lib/stattleship/client.rb
@@ -1,0 +1,46 @@
+module Stattleship
+  class Client
+    BASE_API_URI = URI('https://stattleship.com').freeze
+
+    def initialize(path:, token:)
+      @path = path
+      @token = token
+    end
+
+    def headers
+      {
+        'Accept' => 'application/vnd.stattleship.com; version=1',
+        'Authorization' => "Token token=#{token}",
+        'Content-Type' => 'application/json',
+        'User-Agent' => "Stattleship Ruby/#{Stattleship::Ruby::VERSION} (#{RUBY_PLATFORM})"
+      }
+    end
+
+    def fetch
+      configure_http
+
+      begin
+        http.request(endpoint)
+      rescue StandardError => e
+        puts "HTTP Request failed (#{e.message})"
+      end
+    end
+
+    private
+
+    attr_reader :path, :token
+
+    def http
+      @http ||= Net::HTTP.new(BASE_API_URI.host, BASE_API_URI.port)
+    end
+
+    def configure_http
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    end
+
+    def endpoint
+      @endpoint ||= Net::HTTP::Get.new("#{BASE_API_URI}/#{path}", headers)
+    end
+  end
+end

--- a/lib/stattleship/client.rb
+++ b/lib/stattleship/client.rb
@@ -16,27 +16,14 @@ module Stattleship
     end
 
     def fetch
-      configure_http
-
-      begin
-        http.request(endpoint)
+      Stattleship.configuration.http.request(endpoint)
       rescue StandardError => e
         puts "HTTP Request failed (#{e.message})"
-      end
     end
 
     private
 
     attr_reader :base_uri, :path, :token
-
-    def http
-      @http ||= Net::HTTP.new(base_uri.host, base_uri.port)
-    end
-
-    def configure_http
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    end
 
     def endpoint
       @endpoint ||= Net::HTTP::Get.new("#{base_uri}/#{path}", headers)

--- a/lib/stattleship/configuration.rb
+++ b/lib/stattleship/configuration.rb
@@ -16,6 +16,6 @@ module Stattleship
   end
 
   class Configuration
-    attr_accessor :api_token
+    attr_accessor :api_token, :base_uri
   end
 end

--- a/lib/stattleship/configuration.rb
+++ b/lib/stattleship/configuration.rb
@@ -20,7 +20,7 @@ module Stattleship
     attr_writer :base_uri
 
     def base_uri
-      @base_uri ||= URI('https://stattleship.com')
+      @base_uri ||= URI('https://www.stattleship.com')
     end
   end
 end

--- a/lib/stattleship/configuration.rb
+++ b/lib/stattleship/configuration.rb
@@ -16,6 +16,11 @@ module Stattleship
   end
 
   class Configuration
-    attr_accessor :api_token, :base_uri
+    attr_accessor :api_token
+    attr_writer :base_uri
+
+    def base_uri
+      @base_uri ||= URI('https://stattleship.com')
+    end
   end
 end

--- a/lib/stattleship/configuration.rb
+++ b/lib/stattleship/configuration.rb
@@ -1,0 +1,21 @@
+module Stattleship
+  class << self
+    attr_accessor :configuration
+
+    def configure
+      if block_given?
+        yield configuration
+      end
+
+      configuration
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  class Configuration
+    attr_accessor :api_token
+  end
+end

--- a/lib/stattleship/configuration.rb
+++ b/lib/stattleship/configuration.rb
@@ -17,10 +17,18 @@ module Stattleship
 
   class Configuration
     attr_accessor :api_token
+    attr_reader :http
     attr_writer :base_uri
 
     def base_uri
       @base_uri ||= URI('https://www.stattleship.com')
+    end
+
+    def http
+      @http ||= Net::HTTP.new(base_uri.host, base_uri.port).tap do |http|
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      end
     end
   end
 end

--- a/lib/stattleship/version.rb
+++ b/lib/stattleship/version.rb
@@ -1,5 +1,5 @@
 module Stattleship
   module Ruby
-    VERSION = '0.1.0'
+    VERSION = '0.1.0'.freeze
   end
 end

--- a/lib/stattleship/version.rb
+++ b/lib/stattleship/version.rb
@@ -1,0 +1,5 @@
+module Stattleship
+  module Ruby
+    VERSION = '0.1.0'
+  end
+end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+RSpec.describe Stattleship::Client do
+  describe 'constants' do
+    it 'defines BASE_API_URI' do
+      uri = URI('https://stattleship.com')
+
+      expect(Stattleship::Client::BASE_API_URI).to eq(uri)
+    end
+  end
+
+  describe '#headers' do
+    it 'returns all the header values for Net::HTTP' do
+      client = Stattleship::Client.new(path: 'hockey/nhl/teams',
+                                       token: 'abc123')
+      version = Stattleship::Ruby::VERSION
+      headers = {
+        'Accept' => 'application/vnd.stattleship.com; version=1',
+        'Content-Type' => 'application/json',
+        'Authorization' => 'Token token=abc123',
+        'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
+      }
+
+      expect(client.headers).to eq(headers)
+    end
+  end
+
+  describe '#fetch' do
+    it 'makes a request to Stattleship with headers' do
+      client = Stattleship::Client.new(path: 'hockey/nhl/game_logs',
+                                       token: 'abc123')
+      stub_request(:get, /https:\/\/stattleship.com.*/)
+      version = Stattleship::Ruby::VERSION
+
+      client.fetch
+
+      headers = {
+        'Accept' => 'application/vnd.stattleship.com; version=1',
+        'Content-Type' => 'application/json',
+        'Authorization' => 'Token token=abc123',
+        'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
+      }
+
+      expect(
+        a_request(:get, /https:\/\/stattleship.com.*/).
+        with(headers: headers)
+      ).to have_been_made.once
+    end
+
+    it 'makes a request to Stattleship at a specified url' do
+      path = 'hockey/nhl/game_logs'
+      client = Stattleship::Client.new(path: path, token: 'abc123')
+      stub_request(:get, /https:\/\/stattleship.com.*/)
+
+      client.fetch
+
+      expect(
+        a_request(:get, "https://stattleship.com/#{path}")
+      ).to have_been_made.once
+    end
+  end
+end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Stattleship::Client do
   before(:each) do
     Stattleship.configure do |config|
       config.api_token = 'abc123'
-      config.base_uri = URI('https://stattleship.com')
     end
   end
 

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -19,12 +19,12 @@ module Stattleship
     describe '#fetch' do
       it 'makes a request to Stattleship with headers' do
         client = Client.new(path: 'hockey/nhl/game_logs')
-        stub_request(:get, /https:\/\/www.stattleship.com.*/)
+        stub_request(:get, /#{base_api_url}.*/)
 
         client.fetch
 
         expect(
-          a_request(:get, /https:\/\/www.stattleship.com.*/).
+          a_request(:get, /#{base_api_url}.*/).
           with(headers: headers)
         ).to have_been_made.once
       end
@@ -32,12 +32,12 @@ module Stattleship
       it 'makes a request to Stattleship at a specified url' do
         path = 'hockey/nhl/game_logs'
         client = Stattleship::Client.new(path: path)
-        stub_request(:get, /https:\/\/www.stattleship.com.*/)
+        stub_request(:get, /#{base_api_url}.*/)
 
         client.fetch
 
         expect(
-          a_request(:get, "https://www.stattleship.com/#{path}")
+          a_request(:get, "#{base_api_url}/#{path}")
         ).to have_been_made.once
       end
     end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1,25 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe Stattleship::Client do
-  describe 'constants' do
-    it 'defines BASE_API_URI' do
-      uri = URI('https://stattleship.com')
-
-      expect(Stattleship::Client::BASE_API_URI).to eq(uri)
+  before(:each) do
+    Stattleship.configure do |config|
+      config.api_token = 'abc123'
+      config.base_uri = URI('https://stattleship.com')
     end
   end
 
   describe '#headers' do
     it 'returns all the header values for Net::HTTP' do
-      client = Stattleship::Client.new(path: 'hockey/nhl/teams',
-                                       token: 'abc123')
-      version = Stattleship::Ruby::VERSION
-      headers = {
-        'Accept' => 'application/vnd.stattleship.com; version=1',
-        'Content-Type' => 'application/json',
-        'Authorization' => 'Token token=abc123',
-        'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
-      }
+      client = Stattleship::Client.new(path: 'hockey/nhl/teams')
 
       expect(client.headers).to eq(headers)
     end
@@ -27,19 +18,10 @@ RSpec.describe Stattleship::Client do
 
   describe '#fetch' do
     it 'makes a request to Stattleship with headers' do
-      client = Stattleship::Client.new(path: 'hockey/nhl/game_logs',
-                                       token: 'abc123')
+      client = Stattleship::Client.new(path: 'hockey/nhl/game_logs')
       stub_request(:get, /https:\/\/stattleship.com.*/)
-      version = Stattleship::Ruby::VERSION
 
       client.fetch
-
-      headers = {
-        'Accept' => 'application/vnd.stattleship.com; version=1',
-        'Content-Type' => 'application/json',
-        'Authorization' => 'Token token=abc123',
-        'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
-      }
 
       expect(
         a_request(:get, /https:\/\/stattleship.com.*/).
@@ -49,7 +31,7 @@ RSpec.describe Stattleship::Client do
 
     it 'makes a request to Stattleship at a specified url' do
       path = 'hockey/nhl/game_logs'
-      client = Stattleship::Client.new(path: path, token: 'abc123')
+      client = Stattleship::Client.new(path: path)
       stub_request(:get, /https:\/\/stattleship.com.*/)
 
       client.fetch
@@ -58,5 +40,15 @@ RSpec.describe Stattleship::Client do
         a_request(:get, "https://stattleship.com/#{path}")
       ).to have_been_made.once
     end
+  end
+
+  def headers
+    version = Stattleship::Ruby::VERSION
+    {
+      'Accept' => 'application/vnd.stattleship.com; version=1',
+      'Content-Type' => 'application/json',
+      'Authorization' => 'Token token=abc123',
+      'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
+    }
   end
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -1,53 +1,55 @@
 require 'spec_helper'
 
-RSpec.describe Stattleship::Client do
-  before(:each) do
-    Stattleship.configure do |config|
-      config.api_token = 'abc123'
-    end
-  end
-
-  describe '#headers' do
-    it 'returns all the header values for Net::HTTP' do
-      client = Stattleship::Client.new(path: 'hockey/nhl/teams')
-
-      expect(client.headers).to eq(headers)
-    end
-  end
-
-  describe '#fetch' do
-    it 'makes a request to Stattleship with headers' do
-      client = Stattleship::Client.new(path: 'hockey/nhl/game_logs')
-      stub_request(:get, /https:\/\/stattleship.com.*/)
-
-      client.fetch
-
-      expect(
-        a_request(:get, /https:\/\/stattleship.com.*/).
-        with(headers: headers)
-      ).to have_been_made.once
+module Stattleship
+  RSpec.describe Client do
+    before(:each) do
+      Stattleship.configure do |config|
+        config.api_token = 'abc123'
+      end
     end
 
-    it 'makes a request to Stattleship at a specified url' do
-      path = 'hockey/nhl/game_logs'
-      client = Stattleship::Client.new(path: path)
-      stub_request(:get, /https:\/\/stattleship.com.*/)
+    describe '#headers' do
+      it 'returns all the header values for Net::HTTP' do
+        client = Client.new(path: 'hockey/nhl/teams')
 
-      client.fetch
-
-      expect(
-        a_request(:get, "https://stattleship.com/#{path}")
-      ).to have_been_made.once
+        expect(client.headers).to eq(headers)
+      end
     end
-  end
 
-  def headers
-    version = Stattleship::Ruby::VERSION
-    {
-      'Accept' => 'application/vnd.stattleship.com; version=1',
-      'Content-Type' => 'application/json',
-      'Authorization' => 'Token token=abc123',
-      'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
-    }
+    describe '#fetch' do
+      it 'makes a request to Stattleship with headers' do
+        client = Client.new(path: 'hockey/nhl/game_logs')
+        stub_request(:get, /https:\/\/www.stattleship.com.*/)
+
+        client.fetch
+
+        expect(
+          a_request(:get, /https:\/\/www.stattleship.com.*/).
+          with(headers: headers)
+        ).to have_been_made.once
+      end
+
+      it 'makes a request to Stattleship at a specified url' do
+        path = 'hockey/nhl/game_logs'
+        client = Stattleship::Client.new(path: path)
+        stub_request(:get, /https:\/\/www.stattleship.com.*/)
+
+        client.fetch
+
+        expect(
+          a_request(:get, "https://www.stattleship.com/#{path}")
+        ).to have_been_made.once
+      end
+    end
+
+    def headers
+      version = Stattleship::Ruby::VERSION
+      {
+        'Accept' => 'application/vnd.stattleship.com; version=1',
+        'Content-Type' => 'application/json',
+        'Authorization' => 'Token token=abc123',
+        'User-Agent' => "Stattleship Ruby/#{version} (#{RUBY_PLATFORM})"
+      }
+    end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module Stattleship
+  RSpec.describe Configuration do
+    context 'un-configured' do
+      it 'returns the configuration object' do
+        configuration = Stattleship.configure
+
+        expect(configuration).to be_a(Configuration)
+      end
+    end
+
+    context 'pre-configured' do
+      before(:each) do
+        Stattleship.configure do |config|
+          config.api_token = 'abc123'
+        end
+      end
+
+      it 'returns the configuration object' do
+        configure = Stattleship.configure
+        configuration = Stattleship.configuration
+
+        expect(configure).to be_a(Configuration)
+        expect(configure).to be(configuration)
+      end
+
+      describe 'api_token' do
+        it 'sets the api token' do
+          key = Stattleship.configuration.api_token
+
+          expect(key).to eq('abc123')
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -8,6 +8,14 @@ module Stattleship
 
         expect(configuration).to be_a(Configuration)
       end
+
+      describe '#base_uri' do
+        it 'defaults to a preset url if none is set' do
+          config = Stattleship.configuration
+
+          expect(config.base_uri).to eq(URI('https://stattleship.com'))
+        end
+      end
     end
 
     context 'fully-configured' do

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -13,7 +13,7 @@ module Stattleship
         it 'defaults to a preset url if none is set' do
           config = Stattleship.configuration
 
-          expect(config.base_uri).to eq(URI('https://stattleship.com'))
+          expect(config.base_uri).to eq(URI(base_api_url))
         end
       end
     end
@@ -22,7 +22,7 @@ module Stattleship
       before(:each) do
         Stattleship.configure do |config|
           config.api_token = 'abc123'
-          config.base_uri = URI('https://stattleship.com')
+          config.base_uri = URI(base_api_url)
         end
       end
 
@@ -38,7 +38,7 @@ module Stattleship
         config = Stattleship.configuration
 
         expect(config.api_token).to eq('abc123')
-        expect(config.base_uri).to eq(URI('https://stattleship.com'))
+        expect(config.base_uri).to eq(URI(base_api_url))
       end
     end
   end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -10,10 +10,11 @@ module Stattleship
       end
     end
 
-    context 'pre-configured' do
+    context 'fully-configured' do
       before(:each) do
         Stattleship.configure do |config|
           config.api_token = 'abc123'
+          config.base_uri = URI('https://stattleship.com')
         end
       end
 
@@ -25,12 +26,11 @@ module Stattleship
         expect(configure).to be(configuration)
       end
 
-      describe 'api_token' do
-        it 'sets the api token' do
-          key = Stattleship.configuration.api_token
+      it 'sets the config values' do
+        config = Stattleship.configuration
 
-          expect(key).to eq('abc123')
-        end
+        expect(config.api_token).to eq('abc123')
+        expect(config.base_uri).to eq(URI('https://stattleship.com'))
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'rspec'
+require 'stattleship'
+require 'webmock/rspec'
+
+Dir['spec/support/**/*.rb'].each { |file| require file }
+
+WebMock.disable_net_connect!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,11 @@ require 'rspec'
 require 'stattleship'
 require 'webmock/rspec'
 
-Dir['spec/support/**/*.rb'].each { |file| require file }
+Dir['spec/support/**/*.rb'].each { |file| require File.expand_path(file) }
 
 RSpec.configure do |config|
   config.order = 'random'
+  config.include Constants
 end
 
 WebMock.disable_net_connect!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,8 @@ require 'webmock/rspec'
 
 Dir['spec/support/**/*.rb'].each { |file| require file }
 
+RSpec.configure do |config|
+  config.order = 'random'
+end
+
 WebMock.disable_net_connect!

--- a/spec/support/constants.rb
+++ b/spec/support/constants.rb
@@ -1,0 +1,5 @@
+module Constants
+  def base_api_url
+    'https://www.stattleship.com'
+  end
+end

--- a/stattleship-ruby.gemspec
+++ b/stattleship-ruby.gemspec
@@ -1,0 +1,24 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'stattleship/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'stattleship-ruby'
+  spec.version       = Stattleship::Ruby::VERSION
+  spec.authors       = ['Stattleship', 'Edward Loveall']
+  spec.email         = ['support@stattleship.com']
+
+  spec.summary       = 'Stattleship API Ruby client'
+  spec.description   = 'Connect to and retrive data from the Stattleship API'
+  spec.homepage      = 'http://playbook.stattleship.com'
+  spec.license       = 'MIT'
+
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.require_paths = ['lib']
+
+  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
+end


### PR DESCRIPTION
We now have a basic gem skeleton, tests, a Client class and a Configuration class.

Client takes a string like `'hockey/nhl/game_logs'` and calls the Stattleship api with correct headers and security:

``` ruby
Stattleship::Client.new(path: 'hockey/nhl/game_logs')

#> JSON Response...
```

Configuration can be used like most configuration patterns:

``` ruby
Stattleship.configure do |config|
  config.api_token = 'abc123'
end
```

Currently it can take two values `api_token` and `base_uri`. `base_uri` is never meant to be set by the user, but it gives us a choke point to access and set that url if we need it.
